### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ function Demo() {
       source={source}
       rehypeRewrite={(node, index, parent) => {
         if (node.tagName === "a" && parent && /^h(1|2|3|4|5|6)/.test(parent.tagName)) {
-          parent.children = [parent.children[1]];
+          parent.children = parent.children.slice(1)
         }
       }}
     />


### PR DESCRIPTION
Fix a bug in `Disable Header links` example section.

Given a heading:

```
# A demo of `react-markdown`
```

Example will yield:

```
<h1>A demo of</h1>
```

Which is not correct, the text `react-markdown` is ignored.

With the fix, example will yield correct output:

```
<h1>A demo of <code>react-markdown</code></h1>
```