### PR TITLE
fix(style): :tada: update img element.

### DIFF
--- a/src/styles/markdown.less
+++ b/src/styles/markdown.less
@@ -277,6 +277,7 @@ body[data-color-mode*='light'] {
   }
 
   img {
+    display: inline-block;
     border-style: none;
     max-width: 100%;
     box-sizing: content-box;


### PR DESCRIPTION
Most of the most popular CSS libraries used with React define "display: block" in the "img" tag by default. For this reason, two img elements that need to be next to each other must be one under the other.

To give a direct example, Tailwind and Bootstrap.

While working with React, Tailwind and react-markdown-preview, this problem, which started with two img elements that should be side by side, caused me exactly 2 nights;(

When I found the problem, I checked other popular CSS libraries, same situation.