### PR TITLE
Export markdown.css

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -8,6 +8,7 @@
   "exports": {
     "./README.md": "./README.md",
     "./package.json": "./package.json",
+    "./markdown.css": "./markdown.css",
     ".": {
       "import": "./esm/index.js",
       "types": "./lib/index.d.ts",


### PR DESCRIPTION
I used this library in nextjs project with yarn v3. When upgrading to yarn v4, suddenly it showed as, 

```
./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[8].oneOf[14].use[1]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[8].oneOf[14].use[2]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[8].oneOf[14].use[3]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[8].oneOf[14].use[4]!./styles/globals.scss
Error: Package path ./markdown.css is not exported from package /var/www/web-lan-nywhan/node_modules/@uiw/react-markdown-preview (see exports field in /var/www/web-lan-nywhan/node_modules/@uiw/react-markdown-preview/package.json)
```

I can't find the references for the changes in yarn release note, but when I make changes to `package.json` in `node_modules`, it works. 