### PR TITLE
fixed skipHTML bug

### DIFF
--- a/core/src/nohighlight.tsx
+++ b/core/src/nohighlight.tsx
@@ -3,7 +3,6 @@ import MarkdownPreview from './preview';
 import { type PluggableList } from 'unified';
 import rehypeRewrite from 'rehype-rewrite';
 import rehypeAttrs from 'rehype-attr';
-import rehypeRaw from 'rehype-raw';
 import { reservedMeta } from './plugins/reservedMeta';
 import { retrieveMeta } from './plugins/retrieveMeta';
 import { rehypeRewriteHandle, defaultRehypePlugins } from './rehypePlugins';
@@ -14,7 +13,6 @@ export * from './Props';
 export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props, ref) => {
   const rehypePlugins: PluggableList = [
     reservedMeta,
-    rehypeRaw,
     retrieveMeta,
     ...defaultRehypePlugins,
     [rehypeRewrite, { rewrite: rehypeRewriteHandle(props.disableCopy ?? false, props.rehypeRewrite) }],

--- a/core/src/preview.tsx
+++ b/core/src/preview.tsx
@@ -43,7 +43,7 @@ export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props
       return /^[A-Za-z0-9]+$/.test(element.tagName);
     },
   };
-  if (skipHtml) {
+  if (!skipHtml) {
     rehypePlugins.push(raw);
   }
   const remarkPlugins = [remarkAlert, ...(other.remarkPlugins || []), gfm];
@@ -53,7 +53,7 @@ export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props
       <ReactMarkdown
         {...customProps}
         {...other}
-        skipHtml={skipHtml}
+        skipHtml={!skipHtml}
         urlTransform={urlTransform || defaultUrlTransform}
         rehypePlugins={pluginsFilter ? pluginsFilter('rehype', rehypePlugins) : rehypePlugins}
         remarkPlugins={pluginsFilter ? pluginsFilter('remark', remarkPlugins) : remarkPlugins}


### PR DESCRIPTION
# Bug: skipHTML prop on was not doing anything. The bug persisted in both
- @uiw/react-markdown-preview
- @uiw/react-markdown-preview/nohighlight

# The way it was: 
`rehypePlugins` array holds the plugins. It adds rehypeRaw in  `index.tsx and nohighlight.tsx`
Then in preview it checks 
```js
  if (skipHtml) {
    rehypePlugins.push(raw);
  }
```
If the `skipHtml` is true, then it adds it again. But it was already added in `index / nohighlight` 

# Solution for nohighlight
rehypeRaw is not added in `nohighlight.tsx` (deleted) it is added in preview based on skipHTML value.

# Solution for index (with highlights)
Not fixed. I can't remove `rehypeRaw` in `index.txt` because 
```
    [rehypePrism, { ignoreMissing: true }],
```
Requires rehypeRaw to exist there.

---
So not solved for with highlighting, but solved for nohighlight
